### PR TITLE
Update sponsored-get-request.mdx

### DIFF
--- a/pages/developer/get-request/sponsored-get-request.mdx
+++ b/pages/developer/get-request/sponsored-get-request.mdx
@@ -114,10 +114,6 @@ Breakdown of the above code:
     load 0rbit-Get-Request.lua
     ```
 
-### Fund your process 
-
-Transfer some $0RBT to your processID. 
-
 ### Call the Handler 
 
     Call the handler, who will create a request for the 0rbit process.


### PR DESCRIPTION
No need to fund process while using sponsored get request. This could cause misunderstanding how sponsored get request work.